### PR TITLE
fix order of parameters and mask for Data.from_pyg

### DIFF
--- a/neuralogic/dataset/tensor.py
+++ b/neuralogic/dataset/tensor.py
@@ -166,11 +166,14 @@ class Data:
         data_list = []
 
         if hasattr(data, "train_mask"):
-            data_list.append(Data(data.x, data.edge_index, data.y, data.edge_attr, data.train_mask))
+            train_mask_index = data.train_mask.nonzero(as_tuple=False).view(-1)
+            data_list.append(Data(data.x, data.edge_index, data.y, data.edge_attr, train_mask_index))
         if hasattr(data, "test_mask"):
-            data_list.append(Data(data.x, data.edge_index, data.y, data.edge_attr, data.test_mask))
+            test_mask_index = data.test_mask.nonzero(as_tuple=False).view(-1)
+            data_list.append(Data(data.x, data.edge_index, data.y, data.edge_attr, test_mask_index))
         if hasattr(data, "val_mask"):
-            data_list.append(Data(data.x, data.edge_index, data.y, data.edge_attr, data.val_mask))
+            val_mask_index = data.val_mask.nonzero(as_tuple=False).view(-1)
+            data_list.append(Data(data.x, data.edge_index, data.y, data.edge_attr, val_mask_index))
         if len(data_list) == 0:
             data_list.append(Data(data.x, data.edge_index, data.y, data.edge_attr, None))
 

--- a/neuralogic/dataset/tensor.py
+++ b/neuralogic/dataset/tensor.py
@@ -166,13 +166,13 @@ class Data:
         data_list = []
 
         if hasattr(data, "train_mask"):
-            data_list.append(Data(data.x, data.edge_index, data.edge_attr, data.train_mask, data.y))
+            data_list.append(Data(data.x, data.edge_index, data.y, data.edge_attr, data.train_mask))
         if hasattr(data, "test_mask"):
-            data_list.append(Data(data.x, data.edge_index, data.edge_attr, data.test_mask, data.y))
+            data_list.append(Data(data.x, data.edge_index, data.y, data.edge_attr, data.test_mask))
         if hasattr(data, "val_mask"):
-            data_list.append(Data(data.x, data.edge_index, data.edge_attr, data.val_mask, data.y))
+            data_list.append(Data(data.x, data.edge_index, data.y, data.edge_attr, data.val_mask))
         if len(data_list) == 0:
-            data_list.append(Data(data.x, data.edge_index, data.edge_attr, None, data.y))
+            data_list.append(Data(data.x, data.edge_index, data.y, data.edge_attr, None))
 
         return data_list
 


### PR DESCRIPTION
Currently the function for converting Pytorch Geometric datasets into Data objects is broken because of the ordering of parameters. This PR fixes it.